### PR TITLE
Set Content-Type to image/jpeg for uploads

### DIFF
--- a/modules/s3.js
+++ b/modules/s3.js
@@ -7,34 +7,24 @@ AWS.config.secretAccessKey = Config.secretAccessKey;
 AWS.config.region = Config.region;
 
 var s3Bucket = new AWS.S3({params: {Bucket: Config.Bucket}});
-var s3MultiPartUploader = require('s3-upload-stream').Uploader;
 
 var s3 = {};
 
 s3.imageUpload = function (fileStream, path, filename, callback) {
-  var s3 = new s3MultiPartUploader(
-    {
-      "accessKeyId": Config.accessKeyId,
-      "secretAccessKey": Config.secretAccessKey,
-      "region": Config.region
-    },
-    {
-      "Bucket": Config.Bucket,
-      "Key": path + "/" + filename,
-      "ACL": "public-read",
-    },
-    function (err, uploadStream)
-    {
-      if(err)
-        console.log(err, uploadStream);
-      else
-      {
-        uploadStream.on('uploaded', callback);
-
-        fileStream.pipe(uploadStream);
-      }
+  var data = {
+    'Bucket': Config.Bucket,
+    'Key': path + '/' + filename,
+    'ACL': 'public-read',
+    'ContentType': 'image/jpeg',
+    'Body': fileStream
+  };
+  s3Bucket.putObject(data, function (err, data) {
+    if (err) {
+      console.log(err);
+    } else {
+      callback();
     }
-  );
+  });
 };
 
 s3.orderJsonUpload = function (json, callback) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "passport-google": "^0.3.0",
     "passport-google-oauth": "^0.1.5",
     "request": "^2.39.0",
-    "s3-upload-stream": "^0.4.0",
     "static-favicon": "~1.0.0"
   }
 }


### PR DESCRIPTION
We don't need to use the s3-upload-stream library, the default AWS library will do it for us, plus it was wildly out of date
