### PR TITLE
moved the base64work inside of the success promise callback

### DIFF
--- a/public/javascripts/script.js
+++ b/public/javascripts/script.js
@@ -108,7 +108,7 @@ var bindUploadForm = function (event) {
         // cache image base64 to check against
         var img = self.$popover.parents(".event").find("img")[0];
         $(img).parent().addClass("loading");
-        var imageBase64 = getBase64Image(img);
+        var imageBase64;
 
         $.ajax({
           type: "POST",
@@ -122,6 +122,7 @@ var bindUploadForm = function (event) {
           self.$popover.popover("hide"); // Hide popover
 
           // Refresh image
+          imageBase64 = getBase64Image(img);
           var ticks = 0;
           var interval = setInterval(function () { // arbitrary timeout to allow s3 to propagate image
             img.src = img.src;


### PR DESCRIPTION
I have moved the call to getBase64Image inside of the success return due to it erroring when an image is not loaded. Tested as much as I can on local need to deploy to see if this works.
