### PR TITLE
Remove SSH access; the app will be deprecated very soon

### DIFF
--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -17,10 +17,6 @@ Parameters:
     Description: Applied directly as a tag
     Type: String
     Default: memb-eventbriteImages
-  KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instance
-    Type: String
-    Default: aws-membership
   Stage:
     Description: Applied directly as a tag
     Type: String
@@ -87,7 +83,6 @@ Resources:
         - !Ref InstanceSecurityGroup
         - !Ref VulnerabilityScanningSecurityGroup
       InstanceType: !Ref InstanceType
-      KeyName: !Ref KeyName
       IamInstanceProfile: !Ref MembershipAppInstanceProfile
       AssociatePublicIpAddress: true
       UserData:

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -93,7 +93,6 @@ Resources:
       UserData:
           Fn::Base64: !Sub |
             #!/bin/bash -ev
-            /opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -b github-team-keys -t Membership-and-Subscriptions || true
             adduser --system --home /membership --disabled-password membership
             aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/memb-eventbriteImages/memb-eventbriteImages.tgz /tmp
             mkdir /memb-eventbriteImages
@@ -166,13 +165,9 @@ Resources:
   InstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: Open up SSH access and enable HTTP access on the configured port
+      GroupDescription: Enable inbound HTTP access on the configured port
       VpcId: !Ref VpcId
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
-          CidrIp: !Ref AllowedIngressIps
         - IpProtocol: tcp
           FromPort: '3000'
           ToPort: '3000'


### PR DESCRIPTION
Remove SSH access rather than use SSM - this is essentially an unsupported app, due to be deprecated very soon (next 30 days hopefully). It's instance is a Tools image and not an Amigo one and the last build was December. 
AWS Inspector PR will follow tomorrow.
cc @jacobwinch @adamnfish 