### PR TITLE
Adding AWS Inspector by downloading during startup

### DIFF
--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -93,6 +93,9 @@ Resources:
             mkdir /memb-eventbriteImages
             tar -xzf /tmp/memb-eventbriteImages.tgz -C /memb-eventbriteImages
             aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/${App}/${Stage}/eventbriteImages-config.json /memb-eventbriteImages
+            wget -O /tmp/aws-inspector-installer https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install
+            /bin/bash /tmp/aws-inspector-installer
+            rm /tmp/aws-inspector-installer
             /opt/features/nodejs/install.sh
             sudo npm install pm2 -g
             /memb-eventbriteImages/server.sh


### PR DESCRIPTION
This is a temporary measure either till we deprecate the application in ~2 months, or upgrade to an Amigo AMI rather than machine-tools-images, which has node and the Inspector agent baked in; hopefully in a few days.
cc @jacobwinch @adamnfish 