### PR TITLE
Cloudformation and RiffRaff changes to support Amigo Xenial AMI

### DIFF
--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -84,17 +84,41 @@ Resources:
       UserData:
           Fn::Base64: !Sub |
             #!/bin/bash -ev
-            adduser --system --home /membership --disabled-password membership
+
+            # get runnable tar from S3
             aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/memb-eventbriteImages/memb-eventbriteImages.tgz /tmp
-            mkdir /memb-eventbriteImages
-            tar -xzf /tmp/memb-eventbriteImages.tgz -C /memb-eventbriteImages
-            aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/${App}/${Stage}/eventbriteImages-config.json /memb-eventbriteImages
-            wget -O /tmp/aws-inspector-installer https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install
-            /bin/bash /tmp/aws-inspector-installer
-            rm /tmp/aws-inspector-installer
-            /opt/features/nodejs/install.sh
-            sudo npm install pm2 -g
-            /memb-eventbriteImages/server.sh
+            mkdir /etc/gu/memb-eventbriteImages
+            tar -xzf /tmp/memb-eventbriteImages.tgz -C /etc/gu/memb-eventbriteImages
+            aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/${App}/${Stage}/eventbriteImages-config.json /etc/gu/memb-eventbriteImages
+
+            # add user
+            groupadd membership
+            useradd -r -s /usr/bin/nologin -g membership memb-eventbriteImages
+            chown -R memb-eventbriteImages:membership /etc/gu
+
+            # set up logging
+            touch /var/log/memb-eventbriteImages.log
+            chown memb-eventbriteImages:membership /var/log/memb-eventbriteImages.log
+            /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/memb-eventbriteImages.log
+
+            # set up startup daemon
+            cat >/etc/systemd/system/memb-eventbriteImages.service <<EOL
+            [Service]
+            ExecStart=/usr/bin/node /etc/gu/memb-eventbriteImages/bin/www
+            Restart=always
+            StandardOutput=syslog
+            StandardError=syslog
+            SyslogIdentifier=memb-eventbriteImages
+            User=memb-eventbriteImages
+            Group=membership
+            Environment=NODE_ENV=production
+            [Install]
+            WantedBy=multi-user.target
+            EOL
+
+            # Start application
+            systemctl enable memb-eventbriteImages
+            systemctl start memb-eventbriteImages
   MembershipAppRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -41,7 +41,6 @@ Parameters:
   AMIID:
     Type: String
     Description: Amazon Machine Image ID
-    Default:
 Resources:
   EventbriteImagesAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -41,7 +41,7 @@ Parameters:
   AMIID:
     Type: String
     Description: Amazon Machine Image ID
-    Default: ami-094aad897465c769e
+    Default:
 Resources:
   EventbriteImagesAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
@@ -211,7 +211,7 @@ Resources:
   EventbriteImagesLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub ${App}-${Stage}
+      LogGroupName: !Sub ${Stack}-${App}-${Stage}
       RetentionInDays: 14
 Outputs:
   URL:

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -189,10 +189,7 @@ Resources:
     Properties:
       HostedZoneId: /hostedzone/Z8SGOO5042FR9
       Comment: CNAME for AWS ELB
-      Name: !Join
-        - .
-        - - !Sub ${App}-${Stage}
-          - membership-event-management.gutools.co.uk.
+      Name: !Sub ${App}-${Stage}.membership-event-management.gutools.co.uk.
       Type: CNAME
       TTL: '120'
       ResourceRecords:

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -47,7 +47,7 @@ Parameters:
   AMIID:
     Type: String
     Description: Amazon Machine Image ID
-    Default: ami-6857e51b
+    Default: ami-094aad897465c769e
 Resources:
   EventbriteImagesAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
@@ -87,7 +87,7 @@ Resources:
 
             # get runnable tar from S3
             aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/memb-eventbriteImages/memb-eventbriteImages.tgz /tmp
-            mkdir /etc/gu/memb-eventbriteImages
+            mkdir -p /etc/gu/memb-eventbriteImages
             tar -xzf /tmp/memb-eventbriteImages.tgz -C /etc/gu/memb-eventbriteImages
             aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/${App}/${Stage}/eventbriteImages-config.json /etc/gu/memb-eventbriteImages
 

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -21,11 +21,6 @@ Parameters:
     Description: Applied directly as a tag
     Type: String
     Default: PROD
-  SiteDomain:
-    Description: >-
-      Site domain Name (e.g. 'masterclasses-alpha.theguardian.com' or
-      'membership.theguardian.com')
-    Type: String
   SslArn:
     Description: SSL certificate ARN
     Type: String
@@ -41,7 +36,6 @@ Parameters:
     Type: String
     Default: t2.small
     AllowedValues:
-      - t2.micro
       - t2.small
     ConstraintDescription: must be a valid EC2 instance type.
   AMIID:
@@ -193,12 +187,12 @@ Resources:
   EventbriteImagesELBDNSrecord:
     Type: 'AWS::Route53::RecordSet'
     Properties:
-      HostedZoneId: /hostedzone/Z1E4V12LQGXFEC
+      HostedZoneId: /hostedzone/Z8SGOO5042FR9
       Comment: CNAME for AWS ELB
       Name: !Join
         - .
-        - - !Ref SiteDomain
-          - origin.membership.guardianapis.com.
+        - - !Sub ${App}-${Stage}
+          - membership-event-management.gutools.co.uk.
       Type: CNAME
       TTL: '120'
       ResourceRecords:

--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -117,6 +117,8 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -133,6 +135,16 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/${Stack}/${App}/${Stage}/*
+        - PolicyName: PushLogs
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt EventbriteImagesLogGroup.Arn
   MembershipAppInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -196,6 +208,11 @@ Resources:
         - !GetAtt
           - EventbriteImagesElasticLoadBalancer
           - DNSName
+  EventbriteImagesLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub ${App}-${Stage}
+      RetentionInDays: 14
 Outputs:
   URL:
     Description: URL of the EventbriteImages website

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     app: memb-eventbriteImages
     parameters:
       amiTags:
-        Recipe: manage-frontend
+        Recipe: ubuntu-xenial-node-4
         AmigoStage: PROD
       amiParameter: AMIID
       amiEncrypted: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -5,13 +5,13 @@ stacks:
 deployments:
   ami:
     type: ami-cloudformation-parameter
-      app: memb-eventbriteImages
-      parameters:
-        amiTags:
-          Recipe: xenial-membership
-          AmigoStage: PROD
-        amiParameter: AMIID
-        amiEncrypted: true
+    app: memb-eventbriteImages
+    parameters:
+      amiTags:
+        Recipe: xenial-membership
+        AmigoStage: PROD
+      amiParameter: AMIID
+      amiEncrypted: true
   memb-eventbriteImages:
     parameters:
       bucket: membership-dist

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     app: memb-eventbriteImages
     parameters:
       amiTags:
-        Recipe: ubuntu-xenial-node-4
+        Recipe: manage-frontend
         AmigoStage: PROD
       amiParameter: AMIID
       amiEncrypted: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,4 +15,5 @@ deployments:
   memb-eventbriteImages:
     parameters:
       bucket: membership-dist
+    dependencies: [ami]
     type: autoscaling

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,6 +3,15 @@ regions:
 stacks:
 - membership
 deployments:
+  ami:
+    type: ami-cloudformation-parameter
+      app: memb-eventbriteImages
+      parameters:
+        amiTags:
+          Recipe: xenial-membership
+          AmigoStage: PROD
+        amiParameter: AMIID
+        amiEncrypted: true
   memb-eventbriteImages:
     parameters:
       bucket: membership-dist

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     app: memb-eventbriteImages
     parameters:
       amiTags:
-        Recipe: xenial-membership
+        Recipe: ubuntu-xenial-node-4
         AmigoStage: PROD
       amiParameter: AMIID
       amiEncrypted: true

--- a/server.sh
+++ b/server.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-HOME=/home/ubuntu pm2 start /memb-eventbriteImages/bin/www -i max


### PR DESCRIPTION
Made some CloudFormation and RiffRaff changes to support bootstrapping with Amigo Xenial AMI.

Still got to:
- [x] Remove PM2 from package.json
- [x] Bake and test a new ubuntu-xenial-node-4 recipe so that the node version matches.
- [x] Tested SSM works fine
- [x] Log stream created
- [x] See if I can logging to work - it never worked before - morgan is in dev mode ---> this will go in another PR.

![picture 596](https://user-images.githubusercontent.com/1515970/50403046-7077d800-0793-11e9-8819-835a4e3775b2.png)
