### PR TITLE
Separate public/private subnets

### DIFF
--- a/cloud-formation/cloud-formation.yaml
+++ b/cloud-formation/cloud-formation.yaml
@@ -5,10 +5,12 @@ Parameters:
     Type: String
     Description: VpcId of your existing Virtual Private Cloud (VPC)
     Default: vpc-e6e00183
-  Subnets:
-    Type: CommaDelimitedList
-    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
-    Default: 'subnet-cb91ae8d, subnet-a7b74ac2, subnet-179e8063'
+  PrivateVpcSubnets:
+    Description: Private subnets to use for EC2 instances
+    Type: List<AWS::EC2::Subnet::Id>
+  PublicVpcSubnets:
+    Description: Public subnets to use for the ELB
+    Type: List<AWS::EC2::Subnet::Id>
   Stack:
     Description: 'Applied directly as a tag (''membership'', or ''memb-masterclasses'')'
     Type: String
@@ -47,8 +49,7 @@ Resources:
   EventbriteImagesAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
     Properties:
-      AvailabilityZones: !GetAZs ''
-      VPCZoneIdentifier: !Ref Subnets
+      VPCZoneIdentifier: !Ref PrivateVpcSubnets
       LaunchConfigurationName: !Ref EventbriteImagesLaunchConfig
       MinSize: '1'
       MaxSize: '2'
@@ -162,7 +163,7 @@ Resources:
           SSLCertificateId: !Ref SslArn
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
-      Subnets: !Ref Subnets
+      Subnets: !Ref PublicVpcSubnets
       HealthCheck:
         Target: 'HTTP:3000/healthcheck'
         HealthyThreshold: '2'


### PR DESCRIPTION
As part of reconfiguring the Membership VPC to have public & private subnets, I'm going to placing load balancers in the public subnet and instances in the private subnet, as per best security practices. (The original motivation for this was to give [lambdas access to the internet as well as entities within the VPC](https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function/), but having a subnet which is unreachable from the internet has other security benefits too, and is in fact how the Subscriptions VPC is set up.)

As a first step for this, I need to separate out these params in CloudFormation for all of our apps. I'll need to manually upload the new CloudFormation in the console because I need to supply values for these params.

Since this is an ELB classic, I can't simply swap subnets - behind the scenes, it seems to add before it removes, which violates the condition that there be only one subnet per availability zone. So I will initially supply the same subnets used currently for both public & private.

Then, one AZ at a time, I have to remove the subnet for that AZ, update the stack, then add back in the new subnet for that AZ.

Once I've done this for all our ASGs (the process for ALBs is a bit simpler), the final step is to attach new routing tables to the current public subnets, making them private (i.e. the default route goes to a NAT gateway rather than an internet gateway).

- [x] Stack updated for CODE (@paulbrown1982 it seems like there's no CODE stack for this app, does that seem correct?)
- [x] Stack updated for PROD